### PR TITLE
sign-up confirmation now expects a POST request

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -4,27 +4,26 @@ import {
   HttpStatus,
   Post,
   Get,
-  Query,
   UseGuards,
 } from '@nestjs/common';
 import {
   ApiBody,
   ApiOperation,
   ApiResponse,
-  ApiQuery,
   ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthenticateResponseDto } from './dto/authenticate.dto';
 import { AuthService } from './auth.service';
-import { SignUpDto, SignUpResponseDto } from './dto/sign-up.dto';
+import { SignUpDto, SignUpResponseDto, SignUpConfirmDto } from './dto/sign-up.dto';
 import { SignInDto, SignInResponseDto } from './dto/sign-in.dto';
+import { SuccessDto } from 'src/dto/success.dto';
 import { GetUser } from './decorator/get-user.decorator';
 import { User } from 'src/database/schema';
 import { AuthGuard } from './auth.guard';
 
 @Controller('auth')
 export class AuthController {
-  constructor(private readonly authService: AuthService) {}
+  constructor(private readonly authService: AuthService) { }
 
   @Post('/sign-up')
   @ApiOperation({ summary: 'Sign up user using email and password' })
@@ -35,17 +34,13 @@ export class AuthController {
     return await this.authService.signUp(signUpDto);
   }
 
-  // This is a HTTP GET because we expect the user to click on a link to get here
-  @Get('/sign-up/confirm')
+  @Post('/sign-up/confirm')
   @ApiOperation({ summary: 'Confirm new user email and sign in user' })
-  @ApiQuery({
-    name: 'hashed_token',
-    description: 'Email confirmation token hash',
-  })
+  @ApiBody({ type: SignUpConfirmDto })
   @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden.' })
-  @ApiResponse({ status: HttpStatus.OK, type: AuthenticateResponseDto })
-  async confirmSignUp(@Query('hashed_token') hash: string) {
-    return await this.authService.confirmSignUp(hash);
+  @ApiResponse({ status: HttpStatus.OK, type: SuccessDto })
+  async confirmSignUp(@Body() payload: SignUpConfirmDto) {
+    return await this.authService.confirmSignUp(payload.hashedToken);
   }
 
   @Post('/sign-in')

--- a/src/auth/dto/sign-up.dto.ts
+++ b/src/auth/dto/sign-up.dto.ts
@@ -26,3 +26,12 @@ export class SignUpDto {
 }
 
 export class SignUpResponseDto extends SuccessDto {}
+
+export class SignUpConfirmDto {
+  @ApiProperty({ description: 'Token received from confrimation email' })
+  @IsString()
+  @IsNotEmpty()
+  readonly hashedToken: string;
+
+  // support OTP?
+}


### PR DESCRIPTION
## Questions the PR description should answer

### What did you add or change?

Changes request method for `/sign-up/confirm` from `GET` to `POST`

### Which task does this relate to?

#82 

### What important decisions were made?

The endpoint now requires a POST body with the structure:

```json
{
  "hashedToken": "some_token"
}
```

### What steps does someone checking out or reviewing branch need to follow to make the branch work?

No extra steps

### How can a reviewer test the feature / changes?

- Using swagger, sign up a new user. A confirmation email with a link containing a hashed token will be sent
- Copy token from link in (inbucket) mailbox
- Make POST request with payload as above
