### PR TITLE
Add support for account recovery for lost password.

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -6,6 +6,8 @@ import {
   Get,
   UseGuards,
   Query,
+  UnprocessableEntityException,
+  HttpCode,
 } from '@nestjs/common';
 import {
   ApiBody,
@@ -23,6 +25,7 @@ import { GetUser } from './decorator/get-user.decorator';
 import { User } from 'src/database/schema';
 import { AuthGuard } from './auth.guard';
 import { DecodeInviteResponseDto } from './dto/decode-invite.dto';
+import { InitRecoverPasswordDto, PasswordDto, RecoveryTokenAuthDto } from './dto/password.dto';
 
 @Controller('auth')
 export class AuthController {
@@ -75,16 +78,50 @@ export class AuthController {
     description: 'JWT invite token containing the invited user\'s email',
     required: true,
   })
-  @ApiResponse({ 
-    status: HttpStatus.OK, 
+  @ApiResponse({
+    status: HttpStatus.OK,
     description: 'Token successfully decoded',
-    type: DecodeInviteResponseDto 
+    type: DecodeInviteResponseDto
   })
-  @ApiResponse({ 
-    status: HttpStatus.BAD_REQUEST, 
-    description: 'Invalid or expired token' 
+  @ApiResponse({
+    status: HttpStatus.BAD_REQUEST,
+    description: 'Invalid or expired token'
   })
-  async decodeInviteToken(@Query('token') token: string): Promise<DecodeInviteResponseDto> {
-    return await this.authService.verifyInviteToken(token);
+  decodeInviteToken(@Query('token') token: string): DecodeInviteResponseDto {
+    return this.authService.verifyInviteToken(token);
+  }
+
+  @Post('/password')
+  @UseGuards(AuthGuard)
+  @HttpCode(200)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Update password for current user' })
+  @ApiResponse({ status: HttpStatus.OK, type: SuccessDto, description: 'Password was updated successfuly' })
+  @ApiResponse({ status: HttpStatus.UNAUTHORIZED, description: 'Authentication required' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Another error occurred' })
+  async updatePassword(@Body() { password }: PasswordDto, @GetUser() { authId }: User) {
+    if (!authId) {
+      // this should not occur so long as we have `AuthGuard`
+      throw new UnprocessableEntityException('Authenticated user has no `authId`');
+    }
+
+    return await this.authService.updatePassword(authId, password);
+  }
+
+  @Post('/forgot-password')
+  @HttpCode(204)
+  @ApiOperation({ summary: 'Initiate password recovery for a user with the supplied email' })
+  @ApiResponse({ status: HttpStatus.NO_CONTENT, description: 'Password recovery email was sent' })
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'An error occurred' })
+  async forgotPassword(@Body() { email }: InitRecoverPasswordDto) {
+    return await this.authService.sendPasswordRecoveryToken(email);
+  }
+
+  @Post('/recover')
+  @ApiOperation({ summary: 'Authorize a user given their email and a password recovery token' })
+  @ApiResponse({ status: HttpStatus.FORBIDDEN, description: 'Forbidden.' })
+  @ApiResponse({ status: HttpStatus.OK, type: AuthenticateResponseDto })
+  async recoverAccount(@Body() { email, token }: RecoveryTokenAuthDto) {
+    return await this.authService.recoverAccount(email, token)
   }
 }

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -3,6 +3,7 @@ import {
   ForbiddenException,
   HttpStatus,
   Injectable,
+  UnprocessableEntityException,
 } from '@nestjs/common';
 import { SupabaseService } from 'src/supabase/supabase.service';
 import { DatabaseService } from 'src/database/database.service';
@@ -29,7 +30,7 @@ export class AuthService {
     private databaseService: DatabaseService,
     private mailerService: MailerService,
     private config: ConfigService<EnvironmentVariables>,
-  ) {}
+  ) { }
 
   async signIn(signInDto: SignInDto): Promise<SignInResponseDto> {
     const supabase = this.supabaseService.getClient();
@@ -108,20 +109,18 @@ export class AuthService {
         .set({
           authId: authData.user.id,
           displayName: signUpDto.displayName,
-          ...(signUpDto.fullName && { fullName: signUpDto.fullName }),
-          ...(signUpDto.phone && { phone: signUpDto.phone }),
-          ...(signUpDto.country && { country: signUpDto.country }),
+          fullName: signUpDto.fullName,
+          phone: signUpDto.phone,
+          country: signUpDto.country,
         })
         .where(eq(users.email, signUpDto.email));
     } else {
       await this.databaseService.db.insert(users).values({
         email: signUpDto.email,
         displayName: signUpDto.displayName,
-        
-        ...(signUpDto.fullName && { fullName: signUpDto.fullName }),
-        ...(signUpDto.phone && { phone: signUpDto.phone }),
-        ...(signUpDto.country && { country: signUpDto.country }),
-
+        fullName: signUpDto.fullName,
+        phone: signUpDto.phone,
+        country: signUpDto.country,
         authId: authData.user.id,
       });
     }
@@ -200,6 +199,73 @@ export class AuthService {
     });
 
     return msgInfo;
+  }
+
+  async updatePassword(authId: string, password: string) {
+    const supabase = this.supabaseService.getServiceClient();
+    const { error } = await supabase.auth.admin.updateUserById(authId, { password });
+    if (error) {
+      console.error(error);
+      throw new BadRequestException(error);
+    }
+    return {
+      success: true
+    }
+  }
+
+  async sendPasswordRecoveryToken(email: string) {
+    const supabase = this.supabaseService.getServiceClient();
+    const { data, error } = await supabase.auth.admin.generateLink({
+      email,
+      type: 'recovery',
+    });
+    if (error) {
+      throw new BadRequestException({
+        message: 'Failed to initiate password recovery',
+        details: error.message,
+        status: error.status,
+      });
+    }
+
+    const { email_otp } = data.properties
+    const msgInfo = await this.mailerService.send({
+      template: join(__dirname, 'email', 'recovery'),
+      message: {
+        to: email,
+      },
+      locals: {
+        token: email_otp,
+      },
+    });
+
+    const { rejected, rejectedErrors } = msgInfo;
+
+    if (rejected.length > 0) {
+      console.error(rejectedErrors?.at(0))
+      throw new UnprocessableEntityException(
+        'Email sending failed',
+        rejectedErrors?.at(0)?.message
+      )
+    }
+  }
+
+  async recoverAccount(email: string, token: string) {
+    const supabase = this.supabaseService.getClient();
+    const {
+      data: { user, session },
+      error,
+    } = await supabase.auth.verifyOtp({ email, token, type: 'recovery' });
+
+    if (error) {
+      throw new ForbiddenException(error);
+    }
+    if (!user || !session) {
+      // this should not occur if no error above
+      throw new ForbiddenException('Failed to obtain an auth session')
+    }
+
+    // same response as successful signIn
+    return { user, accessToken: session.access_token, success: true };
   }
 
   /**

--- a/src/auth/dto/authenticate.dto.ts
+++ b/src/auth/dto/authenticate.dto.ts
@@ -1,5 +1,6 @@
-import { IsBoolean, IsEmail } from 'class-validator';
+import { IsEmail } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import type { User } from '@supabase/auth-js';
 
 export class AuthenticateDto {
   @ApiProperty({
@@ -12,9 +13,17 @@ export class AuthenticateDto {
 
 export class AuthenticateResponseDto {
   @ApiProperty({
-    example: true,
-    description: 'Indicates if authentication was successful',
+    description: 'Supabase Auth user',
   })
-  @IsBoolean()
+  readonly user: User;
+
+  @ApiProperty({
+    description: 'JWT'
+  })
+  readonly accessToken: string;
+
+  @ApiProperty({
+    description: 'Indicates authentication succeeded'
+  })
   readonly success: boolean;
 }

--- a/src/auth/dto/password.dto.ts
+++ b/src/auth/dto/password.dto.ts
@@ -1,0 +1,23 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsEmail, IsString } from "class-validator";
+
+export class PasswordDto {
+  @ApiProperty({ description: 'Desired user password' })
+  @IsString()
+  readonly password: string
+}
+
+export class InitRecoverPasswordDto {
+  @ApiProperty({
+    description: 'Email for user account to recover',
+    example: 'user@example.com'
+  })
+  @IsEmail()
+  readonly email: string;
+}
+
+export class RecoveryTokenAuthDto extends InitRecoverPasswordDto {
+  @ApiProperty({ description: 'Secret token to authorize recovery attempt' })
+  @IsString()
+  readonly token: string;
+}

--- a/src/auth/email/recovery/html.njk
+++ b/src/auth/email/recovery/html.njk
@@ -1,0 +1,4 @@
+<h2>Reset Password</h2>
+
+<p>Enter the following OTP to reset the password for your user:</p>
+<p>{{ token }}</p>

--- a/src/auth/email/recovery/subject.njk
+++ b/src/auth/email/recovery/subject.njk
@@ -1,0 +1,1 @@
+Reset Password


### PR DESCRIPTION
A user can obtain a temporary session in case of lost password. The user requests an OTP, uses it to "login". OTP is good for one use so user should set a new password for future logins.

## What did you add or change?

Added endpoints:
- `POST /auth/forgot-password` with "email" in body to obtain "token" (OTP). Sent to email
- `POST /auth/recover` with "email" and "token" (OTP) in body as one-time login credentials
- `POST /auth/password` with "password" in body as new password for current user

## Which task does this relate to? (link) (also make sure the task number is in the branch name)

#105 ,#104 

## What important decisions were made?

Send OTP instead of hashed token and formatted link

## What steps does someone checking out or reviewing branch need to follow to make the branch work?

No extra steps

## How can a reviewer test the feature / changes?

- For an existing user with `authId`, call `POST /auth/forgot-password` with their "email"
- Obtain OTP from inbox
- Sign in with OTP: `POST /auth/recover` with "email" and "token" (OTP)
- Set password `POST /auth/password`
